### PR TITLE
Add HTML5 entity connector app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # TestDrive
+
 Repo to test some ideas without any specific focus
+
+## HTML5 Entity Connector
+
+Open `index.html` in a modern browser to create abgerundete Blöcke (entities). 
+Blöcke besitzen Input- und Output-Konnektoren für Ereignisse, Datenströme und Dateien.
+Per Maus lassen sich passende Konnektoren verbinden.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,138 @@
+const workspace = document.getElementById('workspace');
+const connectionsSvg = document.getElementById('connections');
+const addBtn = document.getElementById('add');
+
+let entities = 0;
+const connections = [];
+let dragObj = null;
+let dragOffset = {x:0, y:0};
+let linkLine = null;
+let linkStart = null;
+
+addBtn.addEventListener('click', () => {
+  createEntity(60 + entities*20, 60 + entities*20);
+});
+
+function createEntity(x, y) {
+  entities++;
+  const el = document.createElement('div');
+  el.className = 'entity';
+  el.style.left = x + 'px';
+  el.style.top = y + 'px';
+
+  el.innerHTML = `<div class="title">Entität ${entities}</div>`;
+
+  const types = ['event','data','file'];
+  types.forEach((type, i) => {
+    const top = 30 + i*25;
+    const input = document.createElement('div');
+    input.className = `connector input ${type}`;
+    input.style.top = top + 'px';
+    input.dataset.type = type;
+    input.dataset.mode = 'input';
+    el.appendChild(input);
+
+    const output = document.createElement('div');
+    output.className = `connector output ${type}`;
+    output.style.top = top + 'px';
+    output.dataset.type = type;
+    output.dataset.mode = 'output';
+    el.appendChild(output);
+
+    [input, output].forEach(conn => {
+      conn.addEventListener('mousedown', startLink);
+    });
+  });
+
+  el.addEventListener('mousedown', startDrag);
+
+  workspace.appendChild(el);
+}
+
+function startDrag(e) {
+  if (e.target.classList.contains('connector')) return;
+  dragObj = e.currentTarget;
+  const rect = dragObj.getBoundingClientRect();
+  dragOffset.x = e.clientX - rect.left;
+  dragOffset.y = e.clientY - rect.top;
+  document.addEventListener('mousemove', doDrag);
+  document.addEventListener('mouseup', stopDrag);
+}
+
+function doDrag(e) {
+  if (!dragObj) return;
+  dragObj.style.left = (e.pageX - dragOffset.x) + 'px';
+  dragObj.style.top = (e.pageY - dragOffset.y) + 'px';
+  updateConnections();
+}
+
+function stopDrag() {
+  document.removeEventListener('mousemove', doDrag);
+  document.removeEventListener('mouseup', stopDrag);
+  dragObj = null;
+}
+
+function startLink(e) {
+  e.stopPropagation();
+  linkStart = e.target;
+  const p = center(linkStart);
+  linkLine = createLine(p.x, p.y, p.x, p.y);
+  document.addEventListener('mousemove', drawTempLink);
+  document.addEventListener('mouseup', finishLink);
+}
+
+function drawTempLink(e) {
+  if (!linkLine) return;
+  setLine(linkLine, null, null, e.pageX, e.pageY);
+}
+
+function finishLink(e) {
+  document.removeEventListener('mousemove', drawTempLink);
+  document.removeEventListener('mouseup', finishLink);
+  const target = e.target;
+  if (target.classList && target.classList.contains('connector') &&
+      target.dataset.mode !== linkStart.dataset.mode &&
+      target.dataset.type === linkStart.dataset.type) {
+    const start = center(linkStart);
+    const end = center(target);
+    setLine(linkLine, start.x, start.y, end.x, end.y);
+    connections.push({line: linkLine, from: linkStart, to: target});
+  } else {
+    connectionsSvg.removeChild(linkLine);
+  }
+  linkLine = null;
+  linkStart = null;
+}
+
+function updateConnections() {
+  connections.forEach(c => {
+    const s = center(c.from);
+    const t = center(c.to);
+    setLine(c.line, s.x, s.y, t.x, t.y);
+  });
+}
+
+function createLine(x1, y1, x2, y2) {
+  const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+  setLine(line, x1, y1, x2, y2);
+  line.setAttribute('stroke', '#000');
+  line.setAttribute('stroke-width', '2');
+  connectionsSvg.appendChild(line);
+  return line;
+}
+
+function setLine(line, x1, y1, x2, y2) {
+  if (x1 !== null) line.setAttribute('x1', x1);
+  if (y1 !== null) line.setAttribute('y1', y1);
+  line.setAttribute('x2', x2);
+  line.setAttribute('y2', y2);
+}
+
+function center(el) {
+  const r = el.getBoundingClientRect();
+  return {x: r.left + r.width/2 + window.scrollX, y: r.top + r.height/2 + window.scrollY};
+}
+
+// create initial entity
+createEntity(80,80);
+createEntity(300,180);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <title>Entity Connector</title>
+  <style>
+    body { margin:0; font-family: sans-serif; overflow:hidden; }
+    #toolbar { position:absolute; top:10px; left:10px; z-index:1000; }
+    #workspace { position:relative; width:100vw; height:100vh; background:#f0f0f0; }
+    #connections { position:absolute; top:0; left:0; width:100%; height:100%; pointer-events:none; }
+    .entity { position:absolute; width:150px; background:white; border:1px solid #999; border-radius:10px; padding:20px; box-sizing:border-box; cursor:move; }
+    .entity .title { font-weight:bold; margin-bottom:10px; }
+    .connector { width:12px; height:12px; border-radius:50%; position:absolute; background:#666; cursor:crosshair; }
+    .connector.input { left:-6px; }
+    .connector.output { right:-6px; }
+    .connector.event { background:#ff9800; }
+    .connector.data { background:#2196f3; }
+    .connector.file { background:#4caf50; }
+  </style>
+</head>
+<body>
+<div id="toolbar"><button id="add">Entität hinzufügen</button></div>
+<div id="workspace">
+  <svg id="connections"></svg>
+</div>
+<script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple HTML5 demo allowing users to create rounded entities with event/data/file connectors
- enable mouse-driven connections and drag support
- document usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910444c0b4832ba0f00dd82247484f